### PR TITLE
Respect -DLIB_SUFFIX option to support proper "make install" on systems with lib64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (WITH_GTK2)
 	link_directories(${GTK2_LIBRARY_DIRS})
 	
 	set_target_properties(vkontakte_gtk2 PROPERTIES PREFIX "")
-	install(TARGETS vkontakte_gtk2 DESTINATION "lib/deadbeef")
+	install(TARGETS vkontakte_gtk2 DESTINATION "lib${LIB_SUFFIX}/deadbeef")
 endif ()
 
 if (WITH_GTK3)
@@ -38,7 +38,7 @@ if (WITH_GTK3)
 	link_directories(${GTK2_LIBRARY_DIRS})
 	
 	set_target_properties(vkontakte_gtk3 PROPERTIES PREFIX "")
-	install(TARGETS vkontakte_gtk3 DESTINATION "lib/deadbeef")
+	install(TARGETS vkontakte_gtk3 DESTINATION "lib${LIB_SUFFIX}/deadbeef")
 endif ()
 
 


### PR DESCRIPTION
Some Linux distributions use /usr/lib64 instead of /usr/lib for 64-bit libraries. It includes distros like Slackware, AgiliaLinux, most Gentoo installlations and some others.

A de-facto common way to build CMake-based source in these cases is to provide -DLIB_SUFFIX=64 to cmake options. For example, this way is used in KDE sources.

This patch implements support for this option.
